### PR TITLE
✨ feat: Lambda用ルーターを作成

### DIFF
--- a/lambda_functions/utils/router.py
+++ b/lambda_functions/utils/router.py
@@ -1,0 +1,45 @@
+import re
+
+
+class Router():
+    def __init__(self):
+        self.decorated_functions = {}
+
+    def get(self, path: str):
+        def inner(func):
+            key = self.gen_func_key('get', path)
+            self.decorated_functions[key] = {"path": path, "function": func}
+        return inner
+
+    def post(self, path: str):
+        def inner(func):
+            key = self.gen_func_key('post', path)
+            self.decorated_functions[key] = {"path": path, "function": func}
+        return inner
+
+    def gen_func_key(self, method: str, path: str):
+        # example result: 'get-/documents/{#}/{#}'
+        path_segments = path.strip('/').split('/')
+        root_segment = path_segments[0]
+        segments = "/".join(['{#}']*len(path_segments[1:]))
+        return method.lower() + "-" + f"/{root_segment}/{segments}"
+
+    def get_path_params(self, path_pattern: str, request_path: str):
+        params_dict = {}
+        path_pattern = path_pattern.split('/')
+        request_path = request_path.split('/')
+        for i in range(len(path_pattern)):
+            m = re.match(r"\{[a-z0-9_].*?\}", path_pattern[i])
+            if m:
+                path_param = re.sub(r"[\{,\}]", '', path_pattern[i])
+                params_dict[path_param] = request_path[i]
+
+        return params_dict
+
+    def handler(self, event):
+        method = event["httpMethod"]
+        path = event["path"]
+        key = self.gen_func_key(method, path)
+        target = self.decorated_functions[key]
+        kwargs = self.get_path_params(target['path'], path)
+        target['function'](**kwargs)

--- a/test/test.ipynb
+++ b/test/test.ipynb
@@ -25,6 +25,184 @@
     "user = UserResponse(id=1, name=\"y.morimoto\")\n",
     "vars(user)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ParseResult(scheme='', netloc='', path='/documents/dfge5ttedfgd', params='', query='', fragment='')"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\n",
+    "url = \"/documents/dfge5ttedfgd\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 70,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'document_id': 'sidf0930-s9d90', 'id': 'aaa-bbb'}"
+      ]
+     },
+     "execution_count": 70,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import re\n",
+    "path_pattern = '/documents/{document_id}/{id}'.split('/')\n",
+    "request_path = '/documents/sidf0930-s9d90/aaa-bbb'.split('/')\n",
+    "params_dict = {}\n",
+    "for i in range(len(path_pattern)):\n",
+    "    m = re.match(r\"\\{[a-z0-9_].*?\\}\", path_pattern[i])\n",
+    "    if m:\n",
+    "        path_param = re.sub(r\"[\\{,\\}]\", '', path_pattern[i])\n",
+    "        params_dict[path_param] = request_path[i]\n",
+    "\n",
+    "params_dict"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 77,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/documents/{#}/{#}'"
+      ]
+     },
+     "execution_count": 77,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import re\n",
+    "path = \"/documents/{id}/{document_id}\"\n",
+    "re.sub(r\"\\{[a-z0-9_].*?\\}\", \"{#}\", path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 120,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'get-/documents/{#}/{#}/{#}': {'path': '/documents/{id}/{document_id}/chunk', 'function': <function get_documents at 0x1106e23e0>}, 'post-/documents/{#}/{#}/{#}': {'path': '/documents/{id}/{document_id}/chunk', 'function': <function update_documents at 0x1106e22a0>}}\n",
+      "ドキュメントの取得: id= sidf0930-s9d90\n",
+      "ドキュメントの取得: document_id= sd89sd0-sasd3a\n"
+     ]
+    }
+   ],
+   "source": [
+    "import re\n",
+    "\n",
+    "class Router():\n",
+    "    def __init__(self):\n",
+    "        self.decorated_functions = {}\n",
+    "\n",
+    "    def get(self, path: str):\n",
+    "        def inner(func):\n",
+    "            key = self.gen_func_key('get', path)\n",
+    "            self.decorated_functions[key] = {\"path\": path, \"function\": func}\n",
+    "        return inner\n",
+    "\n",
+    "    def post(self, path: str):\n",
+    "        def inner(func):\n",
+    "            key = self.gen_func_key('post', path)\n",
+    "            self.decorated_functions[key] = {\"path\": path, \"function\": func}\n",
+    "        return inner\n",
+    "\n",
+    "    def gen_func_key(self, method: str, path: str):\n",
+    "        # example result: 'get-/documents/{#}/{#}'\n",
+    "        path_segments = path.strip('/').split('/')\n",
+    "        root_segment = path_segments[0]\n",
+    "        segments = \"/\".join(['{#}']*len(path_segments[1:]))\n",
+    "        return method.lower() + \"-\" + f\"/{root_segment}/{segments}\"\n",
+    "\n",
+    "    def get_path_params(self, path_pattern: str, request_path: str):\n",
+    "        params_dict = {}\n",
+    "        path_pattern = path_pattern.split('/')\n",
+    "        request_path = request_path.split('/')\n",
+    "        for i in range(len(path_pattern)):\n",
+    "            m = re.match(r\"\\{[a-z0-9_].*?\\}\", path_pattern[i])\n",
+    "            if m:\n",
+    "                path_param = re.sub(r\"[\\{,\\}]\", '', path_pattern[i])\n",
+    "                params_dict[path_param] = request_path[i]\n",
+    "\n",
+    "        return params_dict\n",
+    "\n",
+    "    def handler(self, event):\n",
+    "        method = event[\"httpMethod\"]\n",
+    "        path = event[\"path\"]\n",
+    "        key = self.gen_func_key(method, path)\n",
+    "        target = self.decorated_functions[key]\n",
+    "        kwargs = self.get_path_params(target['path'], path)\n",
+    "        target['function'](**kwargs)\n",
+    "\n",
+    "router = Router()\n",
+    "\n",
+    "@router.get('/documents/{id}/{document_id}/chunk')\n",
+    "def get_documents(id: str, document_id: str):\n",
+    "    print(\"ドキュメントの取得: id=\", id)\n",
+    "    print(\"ドキュメントの取得: document_id=\", document_id)\n",
+    "\n",
+    "@router.post('/documents/{id}/{document_id}/chunk')\n",
+    "def update_documents(id: str, document_id: str):\n",
+    "    print(\"ドキュメントの更新: id=\", id)\n",
+    "    print(\"ドキュメントの更新: document_id=\", document_id)\n",
+    "\n",
+    "print(router.decorated_functions)\n",
+    "\n",
+    "# --- lambda handler ---\n",
+    "payload = {\"httpMethod\": \"GET\", \"path\": \"/documents/sidf0930-s9d90/sd89sd0-sasd3a/chunk\"}\n",
+    "router.handler(payload)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 97,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'get-documents/{#}/{#}'"
+      ]
+     },
+     "execution_count": 97,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "method = \"get\"\n",
+    "path = \"/documents/sidf0930-s9d90/asdfsdf\"\n",
+    "path_segments = path.strip('/').split('/')\n",
+    "root_segment = path_segments[0]\n",
+    "segments = \"/\".join(['{#}']*len(path_segments[1:]))\n",
+    "method + \"-\" + f\"{root_segment}/{segments}\""
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## 概要
- Lambda用ルーターを作成し、デコレーション定義だけで簡単にルーティングできるようにしました。

## 使用方法


```python
from lambda_functions.utils.router import Router

router = Router()

@router.get('/documents/{id}')
def get_documents(id: str):
    print("ドキュメントの取得: id=", id)

@router.post('/documents/{id}/{document_id}/chunk')
def update_documents(id: str, document_id: str):
    print("ドキュメントの更新: id=", id)
    print("ドキュメントの更新: document_id=", document_id)
```